### PR TITLE
AKS 배포 방식 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,10 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to AKS
-        run: |
-          kubectl apply -f k8s/deployment.yaml
-          kubectl apply -f k8s/service.yaml
-          kubectl apply -f k8s/ingress.yaml
+        uses: azure/k8s-deploy@v4
+        with:
+          namespace: traveling
+          manifests: |
+            k8s/deployment.yaml
+          images: |
+            ${{ secrets.ACR_LOGIN_SERVER }}/traveling-backend:${{ github.sha }}


### PR DESCRIPTION
kubectl 명령어를 azure/k8s-deploy 액션으로 대체하고, 이미지 태그를 커밋 SHA로 설정